### PR TITLE
Fixed the referencing for nested dirs html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
     </ul>
 
     <h2>Git Stats</h2>
-    <p>Git statistics can be found <a href="http://thoth-station.github.io/gitstats/">here</a>.</p>
+    <p>Git statistics can be found <a href="http://thoth-station.github.io/docs/git-stats/">here</a>.</p>
 
 </body>
 

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
         </h2>
         
         <p>
-          <a class="button cta rounded primary-btn raised" href="/docs/developers">
+          <a class="button cta rounded primary-btn raised" href="/docs/">
             Get started
           </a>
         </p>


### PR DESCRIPTION
Observed page breakdown on thoth-station.ninja documentation page 
- On click of ``Get Started`` button on thoth-station.ninja it triggers to find the index.html file in docs/developers which is located in docs/.
- In the index.html of docs/, it is referenced to gitstats which is docs/git-stats.