### PR TITLE
Add justification when no CPU information is found in the config file

### DIFF
--- a/_j/no_cpu.md
+++ b/_j/no_cpu.md
@@ -1,0 +1,43 @@
+---
+title: No CPU model or no CPU family provided
+---
+
+No CPU model or no CPU family was found in ``.thoth.yaml`` configuration file.
+
+## Issue description
+
+Thoth configuration file has missing CPU information. This information is
+needed when performing recommendations specific to hardware used (especially
+performance related recommendations).
+
+## Affected packages:
+
+This message is not specific to any package.
+
+## Severity
+
+ * WARNING
+
+## Issue fix
+
+Let Thamos CLI discover your CPU and place it to the configuration file
+available. See [Thamos documentation for more info][1].
+
+## Recommendation types
+
+This message can be produced for all the recommendation types available:
+
+ * latest
+ * performance
+ * security
+ * stable
+ * testing
+
+See [this document that describes recommendation types
+listed](http://thoth-station.ninja/recommendation-types).
+
+## Related
+
+ * [Thamos documentation][1]
+
+[1]: https://thoth-station.ninja/docs/developers/thamos/index.html


### PR DESCRIPTION
## Related Issues and Dependencies

See: https://github.com/thoth-station/prescriptions/blob/master/prescriptions/_generic/no_cpu.yaml

## This introduces a breaking change

- [x] No
