### PR TITLE
Provide information when no CVE is found in a release

### DIFF
--- a/_j/no_cve.md
+++ b/_j/no_cve.md
@@ -7,7 +7,7 @@ No known security vulnerability found for the given package release.
 ## Issue description
 
 The recommendation engine did not find any known CVE vulnerabilities for the
-given Python package. See [What is CVE?][2] for more information on the
+given Python package. See [What is a CVE?][2] for more information on the
 security and possible implications.
 
 **NOTE:** If the recommendation type is set to secure, the recommendation


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/pull/2132

## This introduces a breaking change

- [x] No
