### PR TITLE
Add justification when no ABI is found as package-extract was not run

### DIFF
--- a/_j/no_abi.md
+++ b/_j/no_abi.md
@@ -8,7 +8,7 @@ symbols cannot be done.
 
 ## Issue description
 
-Thoth analyses container images to give better guidenance with respect to ABI
+Thoth analyzes container images to give better guidance with respect to ABI
 symbols needed for packages installed into it. As the container image was not
 analyzed by Thoth container image analysis, the recommendation engine cannot
 provide recommendations specific to ABI symbols present in containerized

--- a/_j/no_abi.md
+++ b/_j/no_abi.md
@@ -1,0 +1,58 @@
+---
+title: No ABI information was found for the given container image
+---
+
+The given runtime environment was not analyzed with respect to ABI symbols
+present in the containerized environment hence recommendations specific to ABI
+symbols cannot be done.
+
+## Issue description
+
+Thoth analyses container images to give better guidenance with respect to ABI
+symbols needed for packages installed into it. As the container image was not
+analyzed by Thoth container image analysis, the recommendation engine cannot
+provide recommendations specific to ABI symbols present in containerized
+environments.
+
+## Affected packages
+
+This warning message is not specific to any package.
+
+## Severity
+
+ * WARNING
+
+## Issue fix
+
+Use another containerized runtime environment that is analyzed and available to
+give better guidenance and recommendations specific to the containerized
+environment.
+
+If the containerized environment used is provided by Thoth team, please [raise
+a support issue][2] and let Thoth team know about the containerized environment
+required to run the application.
+
+## Pipeline units
+
+ * [AbiCompatibilitySieve](https://thoth-station.ninja/docs/developers/adviser/thoth.adviser.sieves.html#thoth.adviser.sieves.AbiCompatibilitySieve)
+
+## Recommendation types
+
+This warning message can be produced for any recommendation type:
+
+ * latest
+ * performance
+ * security
+ * stable
+ * testing
+
+See [this document that describes recommendation
+types](http://thoth-station.ninja/recommendation-types).
+
+## Related
+
+ * [Thamos documentation][1]
+ * [thoth-station/support issue tracker][2]
+
+[1]: https://thoth-station.ninja/docs/developers/thamos/index.html
+[2]: https://github.com/thoth-station/support/issues/new/choose


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/adviser/pull/2152
Related: https://github.com/thoth-station/thoth-application/pull/2095
Related:  https://github.com/thoth-station/jupyterlab-requirements/issues/544#issuecomment-948384219

## This introduces a breaking change

- [x] No

