### PR TITLE
Add Kebechet docs to the index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,6 +13,7 @@
       <li><a href="http://thoth-station.github.io/docs/developers/adviser">adviser</a></p></li>
       <li><a href="http://thoth-station.github.io/docs/developers/analyzer">analyzer</a></p></li>
       <li><a href="http://thoth-station.github.io/docs/developers/common">common</a></p></li>
+      <li><a href="http://thoth-station.github.io/docs/developers/kebechet">kebechet</a></p></li>
       <li><a href="http://thoth-station.github.io/docs/developers/lab">lab</a></p></li>
       <li><a href="http://thoth-station.github.io/docs/developers/package-analyzer">package-analyzer</a></p></li>
       <li><a href="http://thoth-station.github.io/docs/developers/package-extract">package-extract</a></p></li>

--- a/index.html
+++ b/index.html
@@ -82,6 +82,9 @@
               <a href="https://github.com/thoth-station/amun-api" class="navbar-item">
                 Amun API
               </a>
+              <a href="/docs/developers/kebechet/index.html" class="navbar-item">
+                Kebechet bot
+              </a>
               <a href="/docs/developers/adviser/index.html" class="navbar-item">
                 thoth-adviser
               </a>


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/kebechet/issues/944
https://github.com/thoth-station/kebechet/pull/850

## This Pull Request implements

Add Kebechet documentation to the index / listing of docs.

## Description

Kebechet docs recently started to be generated with sphinx together with others (https://github.com/thoth-station/kebechet/pull/850).

This is just to add a link to the new docs from the indexes
