### PR TITLE
Add justification for quay clair CVE not found

### DIFF
--- a/_j/no_cve_link_provided.md
+++ b/_j/no_cve_link_provided.md
@@ -1,0 +1,29 @@
+---
+title: CVE link not found
+---
+
+No link was found as a description for the given container image CVE.
+
+## Issue description
+
+Quay Clair usually provides links to justifications for vulnerabilities found during container images security scans, but this is not always the case.
+Here is an example of CVE justification report: https://access.redhat.com/errata/RHSA-2021:3816
+
+## Severity
+
+ * WARNING
+
+## Issue fix
+
+You can try finding more information about a given vulnerability by looking for its reference (examples: `CVE-2021-27922`, `RHSA-2021:3582`).
+## Recommendation types
+
+ * latest
+ * performance
+ * security
+ * stable
+ * testing
+
+See [this document that describes recommendation types
+listed](http://thoth-station.ninja/recommendation-types).
+


### PR DESCRIPTION
## Related Issues and Dependencies

Related to https://github.com/thoth-station/prescriptions-refresh-job/pull/139#pullrequestreview-931855577

## This introduces a breaking change

- No

## This Pull Request implements

Add a justification for links to CVEs not found during Quay Clair security scans. This justification will be provided as a default in prescriptions for container images where no URL for more detail on a given CVE was found.
